### PR TITLE
Allow Clone-ing of BoolVec

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@ struct ReadmeDoctests;
 /// assert_eq!(format!("{bv:b}"), "[11011111, 10000000]")
 /// // You can also apply padding and pretty printing. See formatting specifiers.
 /// ```
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct BoolVec {
     /// The underlying vector holding the bytes
     bytes: Vec<u8>,


### PR DESCRIPTION
Add default implementation of `Clone` to `BoolVec` for easier manipulation; knowing that all its elements are themselves `Clone`-able.

Maybe not implementing it was intentional and I missed something.